### PR TITLE
15 prevent graph relayout

### DIFF
--- a/src/components/Details/DetailsComponent.tsx
+++ b/src/components/Details/DetailsComponent.tsx
@@ -17,7 +17,7 @@ export const DetailsComponent = () => {
   const dispatch = useDispatch();
   const { host, port } = useSelector(selectGremlin);
   const { selectedNode, selectedEdge } = useSelector(selectGraph);
-  const { nodeLabels, nodeLimit, queryHistory, isPhysicsEnabled } =
+  const { nodeLabels, nodeLimit } =
     useSelector(selectOptions);
 
   let hasSelected = false;

--- a/src/components/Details/SettingsComponent.tsx
+++ b/src/components/Details/SettingsComponent.tsx
@@ -26,8 +26,6 @@ import {
 import DeleteIcon from "@mui/icons-material/Delete";
 import { selectGremlin, setHost, setPort } from "../../reducers/gremlinReducer";
 import { refreshNodeLabels } from "../../reducers/graphReducer";
-import { EdgeOptions, Network } from "vis-network";
-import { getGraph } from "../../logics/graph";
 
 
 type NodeLabelListProps = {
@@ -92,8 +90,7 @@ const NodeLabelList = ({ nodeLabels }: NodeLabelListProps) => {
 export const Settings = () => {
   const dispatch = useDispatch();
   const { host, port } = useSelector(selectGremlin);
-  const { nodeLabels, nodeLimit, queryHistory, isPhysicsEnabled } = useSelector(selectOptions);
-  const network = getGraph();
+  const { nodeLabels, nodeLimit, isPhysicsEnabled } = useSelector(selectOptions);
 
   function onHostChanged(host: string) {
     dispatch(setHost(host));
@@ -125,17 +122,6 @@ export const Settings = () => {
 
   function onTogglePhysics(enabled: boolean) {
     dispatch(setIsPhysicsEnabled(enabled));
-
-    if (network instanceof Network) {
-      const edges: EdgeOptions = {
-        smooth: {
-          enabled,
-          roundness: 10,
-          type: enabled ? 'dynamic' : 'continuous',
-        },
-      };
-      network.setOptions({ physics: enabled, edges });
-    }
   }
 
   return (

--- a/src/components/Details/SettingsComponent.tsx
+++ b/src/components/Details/SettingsComponent.tsx
@@ -90,7 +90,7 @@ const NodeLabelList = ({ nodeLabels }: NodeLabelListProps) => {
 export const Settings = () => {
   const dispatch = useDispatch();
   const { host, port } = useSelector(selectGremlin);
-  const { nodeLabels, nodeLimit, isPhysicsEnabled } = useSelector(selectOptions);
+  const { nodeLabels, nodeLimit, graphOptions } = useSelector(selectOptions);
 
   function onHostChanged(host: string) {
     dispatch(setHost(host));
@@ -152,9 +152,9 @@ export const Settings = () => {
           <FormControlLabel
             control={
               <Switch
-                checked={isPhysicsEnabled}
+                checked={graphOptions.isPhysicsEnabled}
                 onChange={() => {
-                  onTogglePhysics(!isPhysicsEnabled);
+                  onTogglePhysics(!graphOptions.isPhysicsEnabled);
                 }}
                 value="physics"
                 color="primary"

--- a/src/components/NetworkGraph/NetworkGraphComponent.tsx
+++ b/src/components/NetworkGraph/NetworkGraphComponent.tsx
@@ -9,7 +9,7 @@ import { getGraph } from "../../logics/graph";
 
 export const NetworkGraphComponent = () => {
   const { nodes, edges } = useSelector(selectGraph);
-  const { networkOptions } = useSelector(selectOptions);
+  const { graphOptions } = useSelector(selectOptions);
   const myRef = useRef(null);
 
   useEffect(() => {
@@ -17,10 +17,10 @@ export const NetworkGraphComponent = () => {
       getGraph(
         myRef.current,
         { nodes, edges },
-        networkOptions
+        graphOptions
       );
     }
-  }, [nodes, edges, networkOptions]);
+  }, [nodes, edges, graphOptions]);
   return <Box className='graph-container' sx={{width: `calc(100% - ${350}px)`}}>
     <Box ref={myRef} sx={{height: 'calc(100vh - 20px)'}} className={'mynetwork'} />
   </Box>;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 const SERVER_URL = 'http://localhost:3001';
 export const QUERY_ENDPOINT = `${SERVER_URL}/query`;
 export const COMMON_GREMLIN_ERROR = 'Invalid query. Please execute a query to get a set of vertices';
-export let GRAPH_IMPL = "vis"
+export let GRAPH_IMPL = "vis" // 'vis' | 'cytoscape' | 'sigma'
 export const ACTIONS = {
   SET_HOST: 'SET_HOST',
   SET_PORT: 'SET_PORT',

--- a/src/logics/graphImpl/cytoImpl.ts
+++ b/src/logics/graphImpl/cytoImpl.ts
@@ -5,64 +5,100 @@ import { ColaLayoutOptions } from "cytoscape-cola";
 import store from "../../app/store";
 import { setSelectedEdge, setSelectedNode } from "../../reducers/graphReducer";
 import cola from "cytoscape-cola";
+import { setIsPhysicsEnabled } from "../../reducers/optionReducer";
 
 let graph: cy.Core | null = null;
+let layout: cy.Layouts | null = null;
+const opts: ColaLayoutOptions = { name: 'cola', infinite: true, animate: true, centerGraph: false, fit: false }
 
 cy.use(cola)
 
 function toCyNode(n: Node): cy.NodeDefinition {
-  return { group: "nodes", data: { ...n, id: n.id?.toString() as string | undefined } }
+  return { group: "nodes", data: { ...n, id: n.id!.toString() } }
 }
 
 function toCyEdge(e: Edge): cy.EdgeDefinition {
   return {
     group: "edges",
-    data: { ...e, id: e.id?.toString(), source: e.from?.toString() || '', target: e.to?.toString() || '' }
+    data: { ...e, id: e.id!.toString(), source: e.from!.toString() , target: e.to!.toString() }
   }
 }
 
 export function getCytoGraph(container?: HTMLElement, data?: GraphData, options?: GraphOptions | undefined): GraphTypes {
-  let nodes: NodeDefinition[] = data?.nodes?.map(x => toCyNode(x)) || []
-  let edges = data?.edges?.map(x => toCyEdge(x)) || []
-  graph = cy({
-    container: container,
-    elements: {
-      nodes: nodes,
-      edges: edges
-    },
-    minZoom: .1,
-    maxZoom: 10,
-    style: [
-      {
-        selector: 'node',
-        style: {
-          label: 'data(id)'
-        }
-      },
-      {
-        selector: 'node[label]',
-        style: {
-          label: 'data(label)'
-        }
-      },
-      {
-        selector: 'edge',
-        style: {
-          width: 1,
-          "curve-style": "bezier",
-          "target-arrow-shape": 'triangle',
-        }
+  if (!graph) {
+    graph = cy({
+        container: container,
+        elements: {
+          nodes: [],
+          edges: []
+        },
+        minZoom: .1,
+        maxZoom: 10,
+        style: [
+          {
+            selector: 'node',
+            style: {
+              label: 'data(id)'
+            }
+          },
+          {
+            selector: 'node[label]',
+            style: {
+              label: 'data(label)'
+            }
+          },
+          {
+            selector: 'edge',
+            style: {
+              width: 1,
+              "curve-style": "bezier",
+              "target-arrow-shape": 'triangle',
+            }
+          }
+        ]
       }
-    ]
-  });
-  const opts: ColaLayoutOptions = { name: 'cola', infinite: true, animate: true, centerGraph: false, fit: false }
-  graph.layout(opts).start()
-  graph.on('tap', 'node', (event) => {
-    store.dispatch(setSelectedNode(event.target.id()))
-  })
-  graph.on('tap', 'edge', (event) => {
-    store.dispatch(setSelectedEdge(event.target.id()))
-  })
+    );
+    layout = graph.layout(opts)
+    layout.start()
+    graph.on('tap', 'node', (event) => {
+      store.dispatch(setSelectedNode(event.target.id()))
+    })
+    graph.on('tap', 'edge', (event) => {
+      store.dispatch(setSelectedEdge(event.target.id()))
+    })
+    graph.on('drag', 'node', e => {
+      store.dispatch(setIsPhysicsEnabled(false))
+    })
+    return graph;
+  }
+  if(container && data) {
+    let nodes: NodeDefinition[] = data.nodes?.map(x => toCyNode(x)) || []
+    let edges = data.edges?.map(x => toCyEdge(x)) || []
+    for(let n of nodes) {
+      if(!graph.nodes().map(x => x.id()).includes(n.data.id!)) {
+        graph.add(n)
+      }
+    }
+    for(let n of graph.nodes()) {
+      if(!nodes.map(x => x.data.id).includes(n.id())) {
+        graph.remove(n)
+      }
+    }
+    for(let e of edges) {
+      if(!graph.edges().map(x => x.id()).includes(e.data.id!)) {
+        graph.add(e)
+      }
+    }
+  }
+  if(options) {
+    if(options.isPhysicsEnabled) {
+      layout?.stop()
+      layout = graph.layout({...opts, ...{infinite: options.isPhysicsEnabled}})
+      layout.start()
+    } else {
+      layout?.stop()
+    }
+  }
 
   return graph;
 }

--- a/src/logics/graphImpl/cytoImpl.ts
+++ b/src/logics/graphImpl/cytoImpl.ts
@@ -1,11 +1,14 @@
-import { Edge, Node, Options } from "vis-network";
+import { Edge, Node } from "vis-network";
 import cy, { NodeDefinition } from "cytoscape";
-import { GraphData } from "../utils";
+import { GraphData, GraphTypes, GraphOptions } from "../utils";
 import { ColaLayoutOptions } from "cytoscape-cola";
 import store from "../../app/store";
 import { setSelectedEdge, setSelectedNode } from "../../reducers/graphReducer";
+import cola from "cytoscape-cola";
 
-let cytoImpl: cy.Core | null = null;
+let graph: cy.Core | null = null;
+
+cy.use(cola)
 
 function toCyNode(n: Node): cy.NodeDefinition {
   return { group: "nodes", data: { ...n, id: n.id?.toString() as string | undefined } }
@@ -18,10 +21,10 @@ function toCyEdge(e: Edge): cy.EdgeDefinition {
   }
 }
 
-export function getCytoGraph(container?: HTMLElement, data?: GraphData, options?: Options | undefined): cy.Core | null {
+export function getCytoGraph(container?: HTMLElement, data?: GraphData, options?: GraphOptions | undefined): GraphTypes {
   let nodes: NodeDefinition[] = data?.nodes?.map(x => toCyNode(x)) || []
   let edges = data?.edges?.map(x => toCyEdge(x)) || []
-  cytoImpl = cy({
+  graph = cy({
     container: container,
     elements: {
       nodes: nodes,
@@ -53,13 +56,13 @@ export function getCytoGraph(container?: HTMLElement, data?: GraphData, options?
     ]
   });
   const opts: ColaLayoutOptions = { name: 'cola', infinite: true, animate: true, centerGraph: false, fit: false }
-  cytoImpl.layout(opts).start()
-  cytoImpl.on('tap', 'node', (event) => {
+  graph.layout(opts).start()
+  graph.on('tap', 'node', (event) => {
     store.dispatch(setSelectedNode(event.target.id()))
   })
-  cytoImpl.on('tap', 'edge', (event) => {
+  graph.on('tap', 'edge', (event) => {
     store.dispatch(setSelectedEdge(event.target.id()))
   })
 
-  return cytoImpl;
+  return graph;
 }

--- a/src/logics/graphImpl/sigmaImpl.ts
+++ b/src/logics/graphImpl/sigmaImpl.ts
@@ -1,95 +1,110 @@
 import FA2Layout from "graphology-layout-forceatlas2/worker";
 import Graph from "graphology";
-import { Options } from "vis-network";
 import Sigma from "sigma";
 import store from "../../app/store";
 import { setSelectedEdge, setSelectedNode } from "../../reducers/graphReducer";
-import { GraphData } from "../utils";
+import { GraphData, GraphTypes, GraphOptions } from "../utils";
+import { setIsPhysicsEnabled } from "../../reducers/optionReducer";
 
-let graph: Graph | null = null;
+const graph: Graph = new Graph();
 let sigma: Sigma | null = null;
 let sigmaLayout: FA2Layout | null = null;
 
-export function getSigmaGraph(container?: HTMLElement, data?: GraphData, options?: Options | undefined): Sigma | null {
+function createSigmaGraph(container: HTMLElement) {
+  const sigma = new Sigma(graph!, container as HTMLElement, {
+    allowInvalidContainer: true,
+    enableEdgeEvents: true,
+    renderEdgeLabels: true,
+  });
+  sigma.on("clickEdge", e => {
+    store.dispatch(setSelectedEdge(e.edge))
+  })
+  sigma.on("clickNode", (e) => {
+    store.dispatch(setSelectedNode(e.node))
+  });
 
+  // State for drag'n'drop
+  let draggedNode: string | null = null;
+  let isDragging = false;
+
+  // On mouse down on a node
+  //  - we enable the drag mode
+  //  - save in the dragged node in the state
+  //  - highlight the node
+  //  - disable the camera so its state is not updated
+  sigma.on("downNode", (e) => {
+    sigmaLayout?.stop()
+    store.dispatch(setIsPhysicsEnabled(false))
+    isDragging = true;
+    draggedNode = e.node;
+    graph!.setNodeAttribute(draggedNode, "highlighted", true);
+  });
+
+  // On mouse move, if the drag mode is enabled, we change the position of the draggedNode
+  sigma.getMouseCaptor().on("mousemovebody", (e) => {
+    if (!isDragging || !draggedNode) return;
+
+    // Get new position of node
+    const pos = sigma!.viewportToGraph(e);
+
+    graph!.setNodeAttribute(draggedNode, "x", pos.x);
+    graph!.setNodeAttribute(draggedNode, "y", pos.y);
+
+    // Prevent sigma to move camera:
+    e.preventSigmaDefault();
+    e.original.preventDefault();
+    e.original.stopPropagation();
+  });
+
+  // On mouse up, we reset the autoscale and the dragging mode
+  sigma.getMouseCaptor().on("mouseup", () => {
+    if (draggedNode) {
+      graph!.removeNodeAttribute(draggedNode, "highlighted");
+    }
+    isDragging = false;
+    draggedNode = null;
+  });
+
+  // Disable the autoscale at the first down interaction
+  sigma.getMouseCaptor().on("mousedown", () => {
+    if (!sigma!.getCustomBBox()) sigma!.setCustomBBox(sigma!.getBBox());
+  });
+  return sigma
+}
+
+export function getSigmaGraph(container?: HTMLElement, data?: GraphData, options?: GraphOptions | undefined): GraphTypes {
+  // create graph if it doesn't exist
   if (!sigma) {
-    graph = new Graph();
-    sigma = new Sigma(graph, container as HTMLElement)
+    sigma = createSigmaGraph(container!)
+    sigmaLayout = new FA2Layout(graph!, {
+      settings: { gravity: .1, linLogMode: true }
+    });
+    if (options?.isPhysicsEnabled) {
+      sigmaLayout.start()
+    }
     return sigma
   }
-  if (container && data && graph) {
-    sigma.kill()
-    graph.clear()
+  // update options
+  if (options) {
+    if(options.isPhysicsEnabled) sigmaLayout?.start(); else sigmaLayout?.stop();
+  }
+  // updates graph data
+  if (container && data) {
     for (let element of data.nodes) {
-      graph!.addNode(element.id!, { x: Math.random(), y: Math.random(), size: 5, label: element.label })
+      if (!graph.nodes().includes(element.id!.toString())) {
+        graph.addNode(element.id!, { x: Math.random(), y: Math.random(), size: 5, label: element.label })
+      }
+    }
+    for (let id of graph!.nodes()) {
+      if(!data.nodes.map(x => x.id!.toString()).includes(id)) {
+        graph.dropNode(id)
+      }
     }
     for (let element of data.edges) {
-      graph!.addDirectedEdgeWithKey(element.id, element.from, element.to, { size: 2, type: 'arrow', label: element.label })
-    }
-    sigma = new Sigma(graph!, container as HTMLElement, {
-      allowInvalidContainer: true,
-      enableEdgeEvents: true,
-      renderEdgeLabels: true,
-    });
-    if (!sigmaLayout) {
-      sigmaLayout = new FA2Layout(graph!, {
-        settings: { gravity: .1, linLogMode: true }
-      });
-    }
-    sigmaLayout.start()
-    sigma.on("clickEdge", e => {
-      store.dispatch(setSelectedEdge(e.edge))
-    })
-    sigma.on("clickNode", (e) => {
-      store.dispatch(setSelectedNode(e.node))
-    });
-
-    // State for drag'n'drop
-    let draggedNode: string | null = null;
-    let isDragging = false;
-
-    // On mouse down on a node
-    //  - we enable the drag mode
-    //  - save in the dragged node in the state
-    //  - highlight the node
-    //  - disable the camera so its state is not updated
-    sigma.on("downNode", (e) => {
-      sigmaLayout?.stop()
-      isDragging = true;
-      draggedNode = e.node;
-      graph!.setNodeAttribute(draggedNode, "highlighted", true);
-    });
-
-    // On mouse move, if the drag mode is enabled, we change the position of the draggedNode
-    sigma.getMouseCaptor().on("mousemovebody", (e) => {
-      if (!isDragging || !draggedNode) return;
-
-      // Get new position of node
-      const pos = sigma!.viewportToGraph(e);
-
-      graph!.setNodeAttribute(draggedNode, "x", pos.x);
-      graph!.setNodeAttribute(draggedNode, "y", pos.y);
-
-      // Prevent sigma to move camera:
-      e.preventSigmaDefault();
-      e.original.preventDefault();
-      e.original.stopPropagation();
-    });
-
-    // On mouse up, we reset the autoscale and the dragging mode
-    sigma.getMouseCaptor().on("mouseup", () => {
-      if (draggedNode) {
-        graph!.removeNodeAttribute(draggedNode, "highlighted");
+      if(!graph.edges().includes(element.id!.toString())) {
+        graph.addDirectedEdgeWithKey(element.id, element.from, element.to, { size: 2, type: 'arrow', label: element.label })
       }
-      isDragging = false;
-      draggedNode = null;
-    });
-
-    // Disable the autoscale at the first down interaction
-    sigma.getMouseCaptor().on("mousedown", () => {
-      if (!sigma!.getCustomBBox()) sigma!.setCustomBBox(sigma!.getBBox());
-    });
-
+    }
   }
   return sigma;
 }

--- a/src/logics/graphImpl/visImpl.ts
+++ b/src/logics/graphImpl/visImpl.ts
@@ -109,9 +109,9 @@ export function getVisNetwork(container?: HTMLElement, data?: GraphData, options
     network.on("dragging", function (params) {
       const edges: EdgeOptions = {
         smooth: {
-          enabled: false,
-          roundness: 10,
+          enabled: true,
           type: 'continuous',
+          roundness: 1,
         },
       };
       network!.setOptions({ physics: false, edges });

--- a/src/logics/graphImpl/visImpl.ts
+++ b/src/logics/graphImpl/visImpl.ts
@@ -64,7 +64,6 @@ function getOptions(options?: GraphOptions) {
 }
 
 export function getVisNetwork(container?: HTMLElement, data?: GraphData, options?: GraphOptions | undefined): GraphTypes {
-  debugger;
   if (network) {
     for (let n of data?.nodes || []) {
       if (!nodes!.get(n.id as Id)) {

--- a/src/logics/graphImpl/visImpl.ts
+++ b/src/logics/graphImpl/visImpl.ts
@@ -1,25 +1,46 @@
-import { EdgeOptions, Network, Options } from "vis-network";
+import { Data, DataInterfaceEdges, DataInterfaceNodes,  EdgeOptions, Network, Options } from "vis-network";
 import cy from "cytoscape";
 import cola from "cytoscape-cola";
 import store from "../../app/store"
 import { setSelectedEdge, setSelectedNode } from "../../reducers/graphReducer";
 import { GraphData } from "../utils";
 import { setIsPhysicsEnabled } from "../../reducers/optionReducer";
+import { Id } from "vis-data/declarations/data-interface";
+import { DataSet } from "vis-data"
 
 cy.use(cola)
 
 let network: Network | null = null;
+const nodes = new DataSet({})
+const edges = new DataSet({})
 
 
 export function getVisNetwork(container?: HTMLElement, data?: GraphData, options?: Options | undefined): Network | null {
+  debugger;
   if (network) {
-    if (data) network.setData(data);
+    for(let n of data?.nodes || []) {
+      if(!nodes!.get(n.id as Id)) {
+        console.log(`add ${n}`)
+        nodes.add(n)
+      }
+    }
+    for(let e of data?.edges || []) {
+      if(!edges!.get(e.id as Id)) {
+        edges.add(e)
+      }
+    }
+    for(let n of nodes.stream().keys()) {
+      if (!data?.nodes.map(x => x.id).includes(n)) {
+        console.log(`remove ${n}`)
+        nodes.remove(n)
+      }
+    }
     if (options) network.setOptions(options);
     return network;
   }
 
   if (container && data) {
-    network = new Network(container, data, options);
+    network = new Network(container, {nodes: nodes as DataInterfaceNodes, edges: edges as DataInterfaceEdges}, options);
     network.on('selectNode', (params?: any) => {
       const nodeId =
         params.nodes && params.nodes.length > 0 ? params.nodes[0] : null;
@@ -42,8 +63,8 @@ export function getVisNetwork(container?: HTMLElement, data?: GraphData, options
         },
       };
       network!.setOptions({ physics: false, edges });
+      store.dispatch(setIsPhysicsEnabled(false))
     });
-    store.dispatch(setIsPhysicsEnabled(false))
   }
 
   return network;

--- a/src/logics/graphImpl/visImpl.ts
+++ b/src/logics/graphImpl/visImpl.ts
@@ -1,46 +1,99 @@
-import { Data, DataInterfaceEdges, DataInterfaceNodes,  EdgeOptions, Network, Options } from "vis-network";
-import cy from "cytoscape";
-import cola from "cytoscape-cola";
+import { DataInterfaceEdges, DataInterfaceNodes, EdgeOptions, Network, Options } from "vis-network";
 import store from "../../app/store"
 import { setSelectedEdge, setSelectedNode } from "../../reducers/graphReducer";
-import { GraphData } from "../utils";
+import { GraphData, GraphOptions, GraphTypes } from "../utils";
 import { setIsPhysicsEnabled } from "../../reducers/optionReducer";
 import { Id } from "vis-data/declarations/data-interface";
 import { DataSet } from "vis-data"
+import Graph from "graphology";
 
-cy.use(cola)
 
 let network: Network | null = null;
 const nodes = new DataSet({})
 const edges = new DataSet({})
+const defaultOptions: Options = {
+  physics: {
+    forceAtlas2Based: {
+      gravitationalConstant: -26,
+      centralGravity: 0.005,
+      springLength: 230,
+      springConstant: 0.18,
+      avoidOverlap: 1.5,
+    },
+    maxVelocity: 40,
+    solver: 'forceAtlas2Based',
+    timestep: 0.35,
+    stabilization: {
+      enabled: true,
+      iterations: 50,
+      updateInterval: 25,
+    },
+  },
+  // layout: {
+  //   hierarchical: {
+  //     enabled: true,
+  //     direction: "UD",
+  //     sortMethod: "directed",
+  //   }
+  // },
+  nodes: {
+    shape: 'dot',
+    size: 20,
+    borderWidth: 2,
+    font: {
+      size: 11,
+    },
+  },
+  edges: {
+    width: 2,
+    font: {
+      size: 11,
+    },
+    smooth: {
+      type: 'dynamic',
+    },
+  },
+} as Options
 
+function getOptions(options?: GraphOptions) {
+  const opts = {...defaultOptions}
+  if(options) {
+    opts.physics.enabled = options.isPhysicsEnabled
+  }
+  return opts
+}
 
-export function getVisNetwork(container?: HTMLElement, data?: GraphData, options?: Options | undefined): Network | null {
+export function getVisNetwork(container?: HTMLElement, data?: GraphData, options?: GraphOptions | undefined): GraphTypes {
   debugger;
   if (network) {
-    for(let n of data?.nodes || []) {
-      if(!nodes!.get(n.id as Id)) {
+    for (let n of data?.nodes || []) {
+      if (!nodes!.get(n.id as Id)) {
         console.log(`add ${n}`)
         nodes.add(n)
       }
     }
-    for(let e of data?.edges || []) {
-      if(!edges!.get(e.id as Id)) {
+    for (let e of data?.edges || []) {
+      if (!edges!.get(e.id as Id)) {
         edges.add(e)
       }
     }
-    for(let n of nodes.stream().keys()) {
+    for (let n of nodes.stream().keys()) {
       if (!data?.nodes.map(x => x.id).includes(n)) {
         console.log(`remove ${n}`)
         nodes.remove(n)
       }
     }
-    if (options) network.setOptions(options);
+    if (options) {
+      network.setOptions(getOptions(options));
+    }
     return network;
   }
 
   if (container && data) {
-    network = new Network(container, {nodes: nodes as DataInterfaceNodes, edges: edges as DataInterfaceEdges}, options);
+    network = new Network(container, {
+      nodes: nodes as DataInterfaceNodes,
+      edges: edges as DataInterfaceEdges
+    }, getOptions(options));
     network.on('selectNode', (params?: any) => {
       const nodeId =
         params.nodes && params.nodes.length > 0 ? params.nodes[0] : null;

--- a/src/logics/utils.ts
+++ b/src/logics/utils.ts
@@ -1,7 +1,9 @@
 import _ from 'lodash';
-import { Edge, Node } from 'vis-network';
+import { Edge, Network, Node } from 'vis-network';
 import { NodeLabel } from '../reducers/optionReducer';
 import getIcon from "../assets/icons";
+import cytoscape from "cytoscape";
+import Sigma from "sigma";
 
 interface NodeData extends Node {
   properties: any;
@@ -9,9 +11,15 @@ interface NodeData extends Node {
   edges?: Edge[];
 }
 
+export type GraphTypes = Sigma | Network | cytoscape.Core | null
+
 export interface GraphData {
   nodes: Node[],
   edges: Edge[]
+}
+
+export interface GraphOptions {
+  isPhysicsEnabled: boolean,
 }
 
 const selectRandomField = (obj: any) => {

--- a/src/reducers/optionReducer.ts
+++ b/src/reducers/optionReducer.ts
@@ -76,6 +76,7 @@ const slice = createSlice({
   reducers: {
     setIsPhysicsEnabled: (state, action) => {
       state.isPhysicsEnabled = _.get(action, 'payload', true);
+      state.networkOptions.physics.isPhysicsEnabled = _.get(action, 'payload', true);
     },
     addQueryHistory: (state, action) => {
       state.queryHistory = [...state.queryHistory, action.payload];

--- a/src/reducers/optionReducer.ts
+++ b/src/reducers/optionReducer.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../app/store';
 import _ from 'lodash';
-import { Options } from 'vis-network';
 import { INITIAL_LABEL_MAPPINGS } from '../constants';
+import { GraphOptions } from "../logics/utils";
 
 export interface NodeLabel {
   type: string;
@@ -12,9 +12,8 @@ export interface NodeLabel {
 type OptionState = {
   nodeLabels: NodeLabel[];
   queryHistory: string[];
-  isPhysicsEnabled: boolean;
   nodeLimit: number;
-  networkOptions: Options;
+  graphOptions: GraphOptions;
 };
 
 const initialNodeLabels: NodeLabel[] = Object.entries(INITIAL_LABEL_MAPPINGS).map(([type, field]) => 
@@ -23,51 +22,10 @@ const initialNodeLabels: NodeLabel[] = Object.entries(INITIAL_LABEL_MAPPINGS).ma
 const initialState: OptionState = {
   nodeLabels: initialNodeLabels,
   queryHistory: [],
-  isPhysicsEnabled: true,
   nodeLimit: 100,
-  networkOptions: {
-    physics: {
-      forceAtlas2Based: {
-        gravitationalConstant: -26,
-        centralGravity: 0.005,
-        springLength: 230,
-        springConstant: 0.18,
-        avoidOverlap: 1.5,
-      },
-      maxVelocity: 40,
-      solver: 'forceAtlas2Based',
-      timestep: 0.35,
-      stabilization: {
-        enabled: true,
-        iterations: 50,
-        updateInterval: 25,
-      },
-    },
-    // layout: {
-    //   hierarchical: {
-    //     enabled: true,
-    //     direction: "UD",
-    //     sortMethod: "directed",
-    //   }
-    // },
-    nodes: {
-      shape: 'dot',
-      size: 20,
-      borderWidth: 2,
-      font: {
-        size: 11,
-      },
-    },
-    edges: {
-      width: 2,
-      font: {
-        size: 11,
-      },
-      smooth: {
-        type: 'dynamic',
-      },
-    },
-  } as Options,
+  graphOptions: {
+    isPhysicsEnabled: true,
+  }
 };
 
 const slice = createSlice({
@@ -75,8 +33,7 @@ const slice = createSlice({
   initialState,
   reducers: {
     setIsPhysicsEnabled: (state, action) => {
-      state.isPhysicsEnabled = _.get(action, 'payload', true);
-      state.networkOptions.physics.isPhysicsEnabled = _.get(action, 'payload', true);
+      state.graphOptions.isPhysicsEnabled = _.get(action, 'payload', true);
     },
     addQueryHistory: (state, action) => {
       state.queryHistory = [...state.queryHistory, action.payload];


### PR DESCRIPTION
To test:

1. create and visualize a small graph.
2. execute `g.addV()`.
3. The positions of the other nodes should not shift.
4. Repeat for 'vis', 'cytoscape', and 'sigma' graph impls.