### PR TITLE
18 details view properties table resizing

### DIFF
--- a/src/components/Details/DetailsComponent.tsx
+++ b/src/components/Details/DetailsComponent.tsx
@@ -84,7 +84,7 @@ export const DetailsComponent = () => {
     return Object.entries(data).map(e => {
 
       return <TableRow>
-        <TableCell style={{ width: '1%' }}><strong>{String(e[0])}</strong></TableCell>
+        <TableCell style={{ width: 1 }}><strong>{String(e[0])}</strong></TableCell>
         <TableCell>
           {!DISABLE_NODE_EDGE_EDIT ? (
             <EditText

--- a/src/components/Details/DetailsComponent.tsx
+++ b/src/components/Details/DetailsComponent.tsx
@@ -84,7 +84,7 @@ export const DetailsComponent = () => {
     return Object.entries(data).map(e => {
 
       return <TableRow>
-        <TableCell><strong>{String(e[0])}</strong></TableCell>
+        <TableCell style={{ width: '1%' }}><strong>{String(e[0])}</strong></TableCell>
         <TableCell>
           {!DISABLE_NODE_EDGE_EDIT ? (
             <EditText

--- a/src/components/Details/DetailsComponent.tsx
+++ b/src/components/Details/DetailsComponent.tsx
@@ -84,12 +84,12 @@ export const DetailsComponent = () => {
     return Object.entries(data).map(e => {
 
       return <TableRow>
-        <TableCell style={{ width: 1 }}><strong>{String(e[0])}</strong></TableCell>
+        <TableCell style={{ width: 1, height: 1 }}><strong>{String(e[0])}</strong></TableCell>
         <TableCell>
           {!DISABLE_NODE_EDGE_EDIT ? (
             <EditText
               name={String(e[0])}
-              style={{ fontSize: '16px', border: '1px solid #ccc' }}
+              style={{ fontSize: '14px', border: '1px solid #ccc', height: '28px', lineHeight: '28px'}}
               onSave={onConfirmEdit}
               defaultValue={String(e[1])}
               showEditButton
@@ -229,11 +229,11 @@ export const DetailsComponent = () => {
             <Table aria-label="simple table">
               <TableBody>
                 <TableRow key={'type'}>
-                  <TableCell scope="row"><strong>Type</strong></TableCell>
+                  <TableCell style={{ width: 1, height: 1 }} scope="row"><strong>Type</strong></TableCell>
                   <TableCell align="left">{String(selectedType)}</TableCell>
                 </TableRow>
                 <TableRow key={'id'}>
-                  <TableCell scope="row"><strong>ID</strong></TableCell>
+                  <TableCell style={{ width: 1, height: 1 }} scope="row"><strong>ID</strong></TableCell>
                   <TableCell align="left">{String(selectedId)}</TableCell>
                 </TableRow>
                 {getRows(selectedProperties)}


### PR DESCRIPTION
"Hacky" sort of change - causes the cells containing property names to always have to expand to fit the entire name, which guarantees the desired behavior and prevents columns from resizing on edits